### PR TITLE
Fix explicit interface implementations for IsCollection associations to be collections.

### DIFF
--- a/Modules/Intent.Modules.Entities.DDD/Decorators/DDDEntityDecorator.cs
+++ b/Modules/Intent.Modules.Entities.DDD/Decorators/DDDEntityDecorator.cs
@@ -2,9 +2,8 @@
 using System.Text;
 using Intent.Modelers.Domain.Api;
 using Intent.Modules.Common.Templates;
-using Intent.Modules.Entities.Templates.DomainEntity;
 using Intent.Modules.Entities.Templates;
-using Intent.Templates;
+using Intent.Modules.Entities.Templates.DomainEntity;
 
 namespace Intent.Modules.Entities.DDD.Decorators
 {
@@ -25,19 +24,12 @@ namespace Intent.Modules.Entities.DDD.Decorators
             }
 
             var sb = new StringBuilder();
-            sb.AppendLine($"        [IntentInitialGen]");
+            sb.AppendLine("        [IntentInitialGen]");
             sb.Append($"        public {@class.Name}(");
-            sb.Append($"{string.Join(", ", @class.Attributes.Select(x => Template.GetTypeName(x.Type)+ " " + x.Name.ToCamelCase()))}");
+            sb.Append($"{string.Join(", ", @class.Attributes.Select(x => Template.GetTypeName(x.Type) + " " + x.Name.ToCamelCase()))}");
             sb.Append($"{(@class.Attributes.Any() && associatedClass.Any() ? ", " : "")}");
-            sb.Append($"{string.Join(", ", associatedClass.Select(x => Template.GetTypeName(x)+ " " + x.Name().ToCamelCase()))}");
-            //foreach (var attribute in @class.Attributes)
-            //{
-            //    sb.Append($"{Template.Types.Get(attribute.Type)} {attribute.Name.ToCamelCase()}{(associatedClass.Any() || attribute != @class.Attributes.Last() ? ", " : "")}");
-            //}
-            //foreach (var associationEnd in associatedClass)
-            //{
-            //    sb.Append($"{Template.NormalizeNamespace(Template.Types.Get(associationEnd))} {associationEnd.Name().ToCamelCase()}{(associationEnd != associatedClass.Last() ? ", " : "")}");
-            //}
+            sb.Append($"{string.Join(", ", associatedClass.Select(x => Template.GetTypeName(x) + " " + x.Name().ToCamelCase()))}");
+
             sb.Append(")");
             sb.AppendLine("        {");
             foreach (var attribute in @class.Attributes)

--- a/Modules/Intent.Modules.Entities.DDD/Decorators/DDDEntityDecoratorRegistration.cs
+++ b/Modules/Intent.Modules.Entities.DDD/Decorators/DDDEntityDecoratorRegistration.cs
@@ -1,8 +1,7 @@
 ﻿using System.ComponentModel;
+using Intent.Engine;
 using Intent.Modules.Common.Registrations;
 using Intent.Modules.Entities.Templates.DomainEntity;
-using Intent.Engine;
-using Intent.Templates;
 
 namespace Intent.Modules.Entities.DDD.Decorators
 {

--- a/Modules/Intent.Modules.Entities.DDD/Decorators/DDDEntityInterfaceDecorator.cs
+++ b/Modules/Intent.Modules.Entities.DDD/Decorators/DDDEntityInterfaceDecorator.cs
@@ -1,15 +1,13 @@
-﻿using System.Collections;
-using Intent.Metadata.Models;
-using Intent.Modelers.Domain.Api;
+﻿using Intent.Modelers.Domain.Api;
 using Intent.Modules.Common;
 using Intent.Modules.Common.CSharp;
 using Intent.Modules.Common.Templates;
 using Intent.Modules.Entities.Templates;
 using Intent.Modules.Entities.Templates.DomainEntityInterface;
-using Intent.Templates;
+using Intent.Modules.Entities.Templates.DomainEntityState;
 using AssociationEndModel = Intent.Modelers.Domain.Api.AssociationEndModel;
 
-namespace Intent.Modules.Entities.Decorators
+namespace Intent.Modules.Entities.DDD.Decorators
 {
     public class DDDEntityInterfaceDecorator : DomainEntityInterfaceDecoratorBase
     {
@@ -21,11 +19,6 @@ namespace Intent.Modules.Entities.Decorators
 
         public override string ConvertAttributeType(AttributeModel attribute)
         {
-            //var @namespace = attribute.Type.GetStereotypeProperty<string>("CommonType", "Namespace");
-            //if (@namespace != null)
-            //{
-            //    return @namespace + "." + attribute.TypeName();
-            //}
             var domainType = attribute.GetStereotypeProperty<string>("DomainType", "Type");
             if (domainType != null)
             {
@@ -50,9 +43,11 @@ namespace Intent.Modules.Entities.Decorators
             {
                 return base.PropertyBefore(associationEnd);
             }
-            var t = CSharpTypeSource.Create(Template.ExecutionContext, DomainEntityInterfaceTemplate.Identifier);
+
+            var name = Template.Types.InContext(DomainEntityInterfaceTemplate.InterfaceContext).Get(associationEnd).Name;
+
             return $@"
-        {Template.NormalizeNamespace(t.GetType(associationEnd).Name)} {associationEnd.Name().ToPascalCase()} {{ get; }}
+        {Template.NormalizeNamespace(name)} {associationEnd.Name().ToPascalCase()} {{ get; }}
 ";
         }
     }

--- a/Modules/Intent.Modules.Entities.DDD/Decorators/DDDEntityInterfaceDecoratorRegistration.cs
+++ b/Modules/Intent.Modules.Entities.DDD/Decorators/DDDEntityInterfaceDecoratorRegistration.cs
@@ -1,10 +1,9 @@
-﻿using Intent.Modules.Entities.Templates.DomainEntityInterface;
-using System.ComponentModel;
-using Intent.Modules.Common.Registrations;
+﻿using System.ComponentModel;
 using Intent.Engine;
-using Intent.Templates;
+using Intent.Modules.Common.Registrations;
+using Intent.Modules.Entities.Templates.DomainEntityInterface;
 
-namespace Intent.Modules.Entities.Decorators
+namespace Intent.Modules.Entities.DDD.Decorators
 {
     [Description(DDDEntityInterfaceDecorator.Id)]
     public class DDDEntityInterfaceDecoratorRegistration : DecoratorRegistration<DomainEntityInterfaceTemplate, DomainEntityInterfaceDecoratorBase>

--- a/Modules/Intent.Modules.Entities.DDD/Decorators/DDDEntityStateDecorator.cs
+++ b/Modules/Intent.Modules.Entities.DDD/Decorators/DDDEntityStateDecorator.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using Intent.Modelers.Domain.Api;
 using Intent.Modules.Common;
+using Intent.Modules.Common.CSharp;
 using Intent.Modules.Common.Templates;
 using Intent.Modules.Entities.Templates;
 using Intent.Modules.Entities.Templates.DomainEntityInterface;
 using Intent.Modules.Entities.Templates.DomainEntityState;
-using Intent.Configuration;
-using Intent.Metadata.Models;
-using Intent.Modelers.Domain.Api;
-using Intent.Modules.Common.CSharp;
 using Intent.Plugins;
-using Intent.Templates;
 
 namespace Intent.Modules.Entities.DDD.Decorators
 {
@@ -26,13 +21,11 @@ namespace Intent.Modules.Entities.DDD.Decorators
 
         private const string ValueObjectBaseClassSetting = "Value Object Base Class";
 
-        private const string DefaultBaseClassSetting = "Default Base Class";
+        private string _aggregateRootBaseClass;
 
-        private string _aggregateRootBaseClass = null;
+        private string _entityBaseClass;
 
-        private string _entityBaseClass = null;
-
-        private string _valueObjectBaseClass = null;
+        private string _valueObjectBaseClass;
 
         public DDDEntityStateDecorator(DomainEntityStateTemplate template) : base(template)
         {
@@ -57,11 +50,6 @@ namespace Intent.Modules.Entities.DDD.Decorators
 
         public override string ConvertAttributeType(AttributeModel attribute)
         {
-            //var @namespace = attribute.Type.GetStereotypeProperty<string>("CommonType", "Namespace");
-            //if (@namespace != null)
-            //{
-            //    return @namespace + "." + attribute.TypeName();
-            //}
             var domainType = attribute.GetStereotypeProperty<string>("DomainType", "Type");
             if (domainType != null)
             {
@@ -101,7 +89,7 @@ namespace Intent.Modules.Entities.DDD.Decorators
             }
             return base.GetBaseClass(@class);
         }
-        
+
         public override string AssociationAfter(AssociationEndModel associationEnd)
         {
             if (!associationEnd.IsNavigable)
@@ -109,9 +97,10 @@ namespace Intent.Modules.Entities.DDD.Decorators
                 return base.AssociationAfter(associationEnd);
             }
 
-            var t = CSharpTypeSource.Create(Template.ExecutionContext, DomainEntityInterfaceTemplate.Identifier, "IEnumerable<{0}>");
+            var name = Template.Types.InContext(DomainEntityStateTemplate.InterfaceContext).Get(associationEnd).Name;
+
             return $@"
-        {Template.NormalizeNamespace(t.GetType(associationEnd).Name)} I{associationEnd.OtherEnd().Class.Name}.{associationEnd.Name().ToPascalCase()} => {associationEnd.Name().ToPascalCase()};
+        {Template.NormalizeNamespace(name)} I{associationEnd.OtherEnd().Class.Name}.{associationEnd.Name().ToPascalCase()} => {associationEnd.Name().ToPascalCase()};
 ";
         }
     }

--- a/Modules/Intent.Modules.Entities.DDD/Decorators/DDDEntityStateDecoratorRegistration.cs
+++ b/Modules/Intent.Modules.Entities.DDD/Decorators/DDDEntityStateDecoratorRegistration.cs
@@ -1,8 +1,7 @@
 ﻿using System.ComponentModel;
+using Intent.Engine;
 using Intent.Modules.Common.Registrations;
 using Intent.Modules.Entities.Templates.DomainEntityState;
-using Intent.Engine;
-using Intent.Templates;
 
 namespace Intent.Modules.Entities.DDD.Decorators
 {

--- a/Modules/Intent.Modules.Entities.DDD/Intent.Modules.Entities.DDD.imodspec
+++ b/Modules/Intent.Modules.Entities.DDD/Intent.Modules.Entities.DDD.imodspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <id>Intent.Entities.DDD</id>
-  <version>3.0.4</version>
+  <version>3.0.5</version>
   <supportedClientVersions>[3.0.0,4.0.0)</supportedClientVersions>
   <summary>Domain Driven Design (DDD) patterns for Intent.Entities</summary>
   <description></description>

--- a/Modules/Intent.Modules.Entities/Intent.Modules.Entities.imodspec
+++ b/Modules/Intent.Modules.Entities/Intent.Modules.Entities.imodspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <id>Intent.Entities</id>
-  <version>3.0.7</version>
+  <version>3.0.8</version>
   <supportedClientVersions>[3.0.0,4.0.0)</supportedClientVersions>
   <summary>Create domain entities and related artifacts.</summary>
   <description></description>

--- a/Modules/Intent.Modules.Entities/Templates/DomainEntityInterface/DomainEntityInterfaceTemplatePartial.cs
+++ b/Modules/Intent.Modules.Entities/Templates/DomainEntityInterface/DomainEntityInterfaceTemplatePartial.cs
@@ -18,7 +18,7 @@ namespace Intent.Modules.Entities.Templates.DomainEntityInterface
     {
         private readonly IMetadataManager _metadataManager;
         public const string Identifier = "Intent.Entities.DomainEntityInterface";
-        private const string OperationsContext = "Operations";
+        public const string InterfaceContext = "Interface";
 
         private readonly IList<DomainEntityInterfaceDecoratorBase> _decorators = new List<DomainEntityInterfaceDecoratorBase>();
 
@@ -32,7 +32,7 @@ namespace Intent.Modules.Entities.Templates.DomainEntityInterface
         {
             AddTypeSource(CSharpTypeSource.Create(ExecutionContext, DomainEntityStateTemplate.TemplateId, "ICollection<{0}>"));
             AddTypeSource(CSharpTypeSource.Create(ExecutionContext, DomainEnumTemplate.TemplateId, "ICollection<{0}>"));
-            Types.AddClassTypeSource(CSharpTypeSource.Create(ExecutionContext, DomainEntityInterfaceTemplate.Identifier), OperationsContext);
+            Types.AddClassTypeSource(CSharpTypeSource.Create(ExecutionContext, Identifier), InterfaceContext);
         }
 
         protected override CSharpFileConfig DefineFileConfig()
@@ -139,7 +139,7 @@ namespace Intent.Modules.Entities.Templates.DomainEntityInterface
         public string GetParametersDefinition(OperationModel operation)
         {
             return operation.Parameters.Any()
-                ? operation.Parameters.Select(x => NormalizeNamespace(Types.InContext(OperationsContext).Get(x.TypeReference).Name) + " " + x.Name.ToCamelCase()).Aggregate((x, y) => x + ", " + y)
+                ? operation.Parameters.Select(x => NormalizeNamespace(Types.InContext(InterfaceContext).Get(x.TypeReference).Name) + " " + x.Name.ToCamelCase()).Aggregate((x, y) => x + ", " + y)
                 : "";
         }
 
@@ -149,7 +149,7 @@ namespace Intent.Modules.Entities.Templates.DomainEntityInterface
             {
                 return o.IsAsync() ? "Task" : "void";
             }
-            return o.IsAsync() ? $"Task<{NormalizeNamespace(Types.InContext(OperationsContext).Get(o.TypeReference).Name)}>" : NormalizeNamespace(Types.InContext(OperationsContext).Get(o.TypeReference).Name);
+            return o.IsAsync() ? $"Task<{NormalizeNamespace(Types.InContext(InterfaceContext).Get(o.TypeReference).Name)}>" : NormalizeNamespace(Types.InContext(InterfaceContext).Get(o.TypeReference).Name);
         }
 
         public IEnumerable<string> DeclareUsings()

--- a/Modules/Intent.Modules.Entities/Templates/DomainEntityState/DomainEntityStateTemplatePartial.cs
+++ b/Modules/Intent.Modules.Entities/Templates/DomainEntityState/DomainEntityStateTemplatePartial.cs
@@ -1,17 +1,13 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Intent.Modules.Common;
-using Intent.Modules.Common.Templates;
-using Intent.Modules.Entities.Templates.DomainEntity;
-using Intent.Modules.Entities.Templates.DomainEntityInterface;
 using Intent.Engine;
-using Intent.Metadata.Models;
 using Intent.Modelers.Domain.Api;
+using Intent.Modules.Common;
 using Intent.Modules.Common.CSharp;
 using Intent.Modules.Common.CSharp.Templates;
-using Intent.Modules.Common.Types.Api;
+using Intent.Modules.Common.Templates;
+using Intent.Modules.Entities.Templates.DomainEntityInterface;
 using Intent.Modules.Entities.Templates.DomainEnum;
 using Intent.Templates;
 
@@ -19,17 +15,17 @@ namespace Intent.Modules.Entities.Templates.DomainEntityState
 {
     partial class DomainEntityStateTemplate : CSharpTemplateBase<ClassModel>, ITemplate, IHasDecorators<DomainEntityStateDecoratorBase>, ITemplatePostCreationHook
     {
-        private readonly IMetadataManager _metadataManager;
         public const string TemplateId = "Intent.Entities.DomainEntityState";
+        public const string InterfaceContext = "Interface";
 
         private readonly IList<DomainEntityStateDecoratorBase> _decorators = new List<DomainEntityStateDecoratorBase>();
 
-        public DomainEntityStateTemplate(ClassModel model, IProject project, IMetadataManager metadataManager)
-            : base(TemplateId, project, model)
+        public DomainEntityStateTemplate(ClassModel model, IOutputTarget outputTarget)
+            : base(TemplateId, outputTarget, model)
         {
-            _metadataManager = metadataManager;
             AddTypeSource(TemplateId, "ICollection<{0}>");
             AddTypeSource(DomainEnumTemplate.TemplateId, "ICollection<{0}>");
+            Types.AddTypeSource(CSharpTypeSource.Create(ExecutionContext, DomainEntityInterfaceTemplate.Identifier, "IEnumerable<{0}>"), InterfaceContext);
         }
 
         public string EntityInterfaceName => Project.FindTemplateInstance<IClassProvider>(TemplateDependency.OnModel(DomainEntityInterfaceTemplate.Identifier, Model))?.ClassName

--- a/Modules/Intent.Modules.Entities/Templates/DomainEntityState/DomainEntityStateTemplateRegistrations.cs
+++ b/Modules/Intent.Modules.Entities/Templates/DomainEntityState/DomainEntityStateTemplateRegistrations.cs
@@ -1,18 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
-using Intent.Modelers.Domain.Api;
-using Intent.Modules.Common;
-using Intent.Modules.Common.Registrations;
-using Intent.SoftwareFactory;
 using Intent.Engine;
-using Intent.Modelers.Domain;
+using Intent.Modelers.Domain.Api;
+using Intent.Modules.Common.Registrations;
 using Intent.Templates;
-
 
 namespace Intent.Modules.Entities.Templates.DomainEntityState
 {
     [Description(DomainEntityStateTemplate.TemplateId)]
-    public class DomainEntityStateTemplateRegistrations : ModelTemplateRegistrationBase<ClassModel>
+    public class DomainEntityStateTemplateRegistrations : FilePerModelTemplateRegistration<ClassModel>
     {
         private readonly IMetadataManager _metadataManager;
 
@@ -23,12 +19,12 @@ namespace Intent.Modules.Entities.Templates.DomainEntityState
 
         public override string TemplateId => DomainEntityStateTemplate.TemplateId;
 
-        public override ITemplate CreateTemplateInstance(IProject project, ClassModel model)
+        public override ITemplate CreateTemplateInstance(IOutputTarget outputTarget, ClassModel model)
         {
-            return new DomainEntityStateTemplate(model, project, _metadataManager);
+            return new DomainEntityStateTemplate(model, outputTarget);
         }
 
-        public override IEnumerable<ClassModel> GetModels(Engine.IApplication application)
+        public override IEnumerable<ClassModel> GetModels(IApplication application)
         {
             return _metadataManager.Domain(application).GetClassModels();
         }

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Intent.Modules.EntityFramework.Repositories.imodspec
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Intent.Modules.EntityFramework.Repositories.imodspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <id>Intent.EntityFramework.Repositories</id>
-  <version>3.0.3</version>
+  <version>3.0.4</version>
   <supportedClientVersions>[3.0.0,4.0.0)</supportedClientVersions>
   <summary>Repository Patterns for Entity Framework.</summary>
   <description>Repository Patterns for Entity Framework.</description>

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Templates/PagedList/PagedListTemplate.cs
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Templates/PagedList/PagedListTemplate.cs
@@ -33,9 +33,9 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.PagedList
         /// </summary>
         public override string TransformText()
         {
-            this.Write("using System.Collections.Generic;\r\nusing System.Data.Entity;\r\nusing System.Linq;\r" +
-                    "\nusing System.Threading.Tasks;\r\n\r\n[assembly: DefaultIntentManaged(Mode.Fully)]\r\n" +
-                    "\r\nnamespace ");
+            this.Write("using System.Collections.Generic;\r\nusing System.Linq;\r\nusing System.Threading;\r\nu" +
+                    "sing System.Threading.Tasks;\r\n\r\n[assembly: DefaultIntentManaged(Mode.Fully)]\r\n\r\n" +
+                    "namespace ");
             
             #line 21 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\PagedList\PagedListTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Namespace));
@@ -102,14 +102,14 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.PagedList
             
             #line default
             #line hidden
-            this.Write(@"<T>> CreateAsync(IQueryable<T> source, int pageNo, int pageSize)
+            this.Write(@"<T>> CreateAsync(IQueryable<T> source, int pageNo, int pageSize, CancellationToken cancellationToken = default)
         {
-            var count = await source.CountAsync();
+            var count = await source.CountAsync(cancellationToken);
             var skip = ((pageNo - 1) * pageSize);
             var results = await source
                 .Skip(skip)
                 .Take(pageSize)
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
             return new ");
             
             #line 61 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\PagedList\PagedListTemplate.tt"
@@ -117,7 +117,7 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.PagedList
             
             #line default
             #line hidden
-            this.Write(@"<T>(totalCount: count, pageNo: pageNo, pageSize: pageSize, results: results);
+            this.Write(@"<T>(count, pageNo, pageSize, results);
         }
 
         private int GetPageCount(int pageSize, int totalCount)

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Templates/PagedList/PagedListTemplate.tt
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Templates/PagedList/PagedListTemplate.tt
@@ -12,8 +12,8 @@
 <#@ import namespace="System.Collections" #>
 <#@ import namespace="System.Collections.Generic" #>
 using System.Collections.Generic;
-using System.Data.Entity;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 [assembly: DefaultIntentManaged(Mode.Fully)]
@@ -50,15 +50,15 @@ namespace <#= Namespace #>
             AddRange(results);
         }
 
-        public static async Task<<#= PagedResultInterfaceName #><T>> CreateAsync(IQueryable<T> source, int pageNo, int pageSize)
+        public static async Task<<#= PagedResultInterfaceName #><T>> CreateAsync(IQueryable<T> source, int pageNo, int pageSize, CancellationToken cancellationToken = default)
         {
-            var count = await source.CountAsync();
+            var count = await source.CountAsync(cancellationToken);
             var skip = ((pageNo - 1) * pageSize);
             var results = await source
                 .Skip(skip)
                 .Take(pageSize)
-                .ToListAsync();
-            return new <#= ClassName #><T>(totalCount: count, pageNo: pageNo, pageSize: pageSize, results: results);
+                .ToListAsync(cancellationToken);
+            return new <#= ClassName #><T>(count, pageNo, pageSize, results);
         }
 
         private int GetPageCount(int pageSize, int totalCount)

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Templates/PagedList/PagedListTemplatePartial.cs
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Templates/PagedList/PagedListTemplatePartial.cs
@@ -1,8 +1,6 @@
 ﻿using Intent.Engine;
 using Intent.Modules.Common;
-using Intent.Modules.Common.CSharp;
 using Intent.Modules.Common.CSharp.Templates;
-using Intent.Modules.Common.Templates;
 using Intent.Modules.Entities.Repositories.Api.Templates.PagedResultInterface;
 using Intent.Templates;
 
@@ -12,8 +10,8 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.PagedList
     {
         public const string Identifier = "Intent.EntityFramework.Repositories.PagedList";
 
-        public PagedListTemplate(IProject project)
-            : base(Identifier, project)
+        public PagedListTemplate(IOutputTarget outputTarget)
+            : base(Identifier, outputTarget)
         {
         }
 
@@ -22,7 +20,7 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.PagedList
         protected override CSharpFileConfig DefineFileConfig()
         {
             return new CSharpFileConfig(
-                className: $"PagedList",
+                className: "PagedList",
                 @namespace: $"{OutputTarget.GetNamespace()}");
         }
     }

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Templates/PagedList/PagedListTemplateRegistration.cs
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Templates/PagedList/PagedListTemplateRegistration.cs
@@ -1,30 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
+﻿using System.ComponentModel;
 using Intent.Engine;
-using Intent.Modelers.Domain.Api;
-using Intent.Modules.Common;
 using Intent.Modules.Common.Registrations;
-using Intent.Modules.EntityFramework.Repositories.Templates.PagedList;
 using Intent.Templates;
 
-namespace Intent.Modules.EntityFrameworkCore.Repositories.Templates.PagedList
+namespace Intent.Modules.EntityFramework.Repositories.Templates.PagedList
 {
     [Description(PagedListTemplate.Identifier)]
-    public class PagedListTemplateRegistration : NoModelTemplateRegistrationBase
+    public class PagedListTemplateRegistration : SingleFileTemplateRegistration
     {
-        private readonly IMetadataManager _metadataManager;
-
-        public PagedListTemplateRegistration(IMetadataManager metadataManager)
-        {
-            _metadataManager = metadataManager;
-        }
-
         public override string TemplateId => PagedListTemplate.Identifier;
-        public override ITemplate CreateTemplateInstance(IProject project)
+
+        public override ITemplate CreateTemplateInstance(IOutputTarget outputTarget)
         {
-            return new PagedListTemplate(project);
+            return new PagedListTemplate(outputTarget);
         }
     }
 }

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Templates/Repository/RepositoryTemplate.cs
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Templates/Repository/RepositoryTemplate.cs
@@ -33,16 +33,16 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.Repository
         /// </summary>
         public override string TransformText()
         {
-            this.Write("using System;\r\nusing System.Data.Entity;\r\nusing System.Linq;\r\nusing System.Linq.E" +
-                    "xpressions;\r\nusing System.Threading.Tasks;\r\n\r\n[assembly: DefaultIntentManaged(Mo" +
-                    "de.Ignore)]\r\n\r\nnamespace ");
+            this.Write("using System;\r\nusing System.Collections.Generic;\r\nusing System.Linq;\r\nusing Syste" +
+                    "m.Threading;\r\nusing System.Threading.Tasks;\r\n\r\n[assembly: DefaultIntentManaged(M" +
+                    "ode.Ignore)]\r\n\r\nnamespace ");
             
             #line 23 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\Repository\RepositoryTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Namespace));
             
             #line default
             #line hidden
-            this.Write("\r\n{\r\n    [IntentManaged(Mode.Merge)]\r\n\tpublic class ");
+            this.Write("\r\n{\r\n    [IntentManaged(Mode.Merge)]\r\n    public class ");
             
             #line 26 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\Repository\RepositoryTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(ClassName));
@@ -91,29 +91,53 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.Repository
             
             #line default
             #line hidden
-            this.Write(" dbContext) : base (dbContext)\r\n        {\r\n        }\r\n\r\n        public async Task" +
-                    "<");
+            this.Write(" dbContext) : base (dbContext)\r\n        {\r\n        }\r\n\r\n        [IntentManaged(Mo" +
+                    "de.Fully)]\r\n        public async Task<");
             
-            #line 32 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\Repository\RepositoryTemplate.tt"
+            #line 33 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\Repository\RepositoryTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(EntityInterfaceName));
             
             #line default
             #line hidden
             this.Write("> FindByIdAsync(");
             
-            #line 32 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\Repository\RepositoryTemplate.tt"
+            #line 33 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\Repository\RepositoryTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(PrimaryKeyType));
             
             #line default
             #line hidden
-            this.Write(" id)\r\n        {\r\n            return await FindAsync(x => x.");
+            this.Write(" id, CancellationToken cancellationToken = default)\r\n        {\r\n            retur" +
+                    "n await FindAsync(x => x.");
             
-            #line 34 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\Repository\RepositoryTemplate.tt"
+            #line 35 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\Repository\RepositoryTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(PrimaryKeyName));
             
             #line default
             #line hidden
-            this.Write(" == id);\r\n        }\r\n    }\r\n}");
+            this.Write(" == id, cancellationToken);\r\n        }\r\n\r\n        [IntentManaged(Mode.Fully)]\r\n  " +
+                    "      public async Task<List<");
+            
+            #line 39 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\Repository\RepositoryTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(EntityInterfaceName));
+            
+            #line default
+            #line hidden
+            this.Write(">> FindByIdsAsync(");
+            
+            #line 39 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\Repository\RepositoryTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(PrimaryKeyType));
+            
+            #line default
+            #line hidden
+            this.Write("[] ids, CancellationToken cancellationToken = default)\r\n        {\r\n            re" +
+                    "turn await FindAllAsync(x => ids.Contains(x.");
+            
+            #line 41 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\Repository\RepositoryTemplate.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(PrimaryKeyName));
+            
+            #line default
+            #line hidden
+            this.Write("), cancellationToken);\r\n        }\r\n    }\r\n}");
             return this.GenerationEnvironment.ToString();
         }
     }

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Templates/Repository/RepositoryTemplate.tt
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Templates/Repository/RepositoryTemplate.tt
@@ -13,9 +13,9 @@
 <#@ import namespace="System.Collections" #>
 <#@ import namespace="System.Collections.Generic" #>
 using System;
-using System.Data.Entity;
+using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 [assembly: DefaultIntentManaged(Mode.Ignore)]
@@ -23,15 +23,22 @@ using System.Threading.Tasks;
 namespace <#= Namespace #>
 {
     [IntentManaged(Mode.Merge)]
-	public class <#= ClassName #> : RepositoryBase<<#= EntityInterfaceName #>, <#= EntityName #>, <#= DbContextName #>>, <#= RepositoryContractName #>
+    public class <#= ClassName #> : RepositoryBase<<#= EntityInterfaceName #>, <#= EntityName #>, <#= DbContextName #>>, <#= RepositoryContractName #>
     {
         public <#= ClassName #>(<#= DbContextName #> dbContext) : base (dbContext)
         {
         }
 
-        public async Task<<#= EntityInterfaceName #>> FindByIdAsync(<#= PrimaryKeyType #> id)
+        [IntentManaged(Mode.Fully)]
+        public async Task<<#= EntityInterfaceName #>> FindByIdAsync(<#= PrimaryKeyType #> id, CancellationToken cancellationToken = default)
         {
-            return await FindAsync(x => x.<#= PrimaryKeyName #> == id);
+            return await FindAsync(x => x.<#= PrimaryKeyName #> == id, cancellationToken);
+        }
+
+        [IntentManaged(Mode.Fully)]
+        public async Task<List<<#= EntityInterfaceName #>>> FindByIdsAsync(<#= PrimaryKeyType #>[] ids, CancellationToken cancellationToken = default)
+        {
+            return await FindAllAsync(x => ids.Contains(x.<#= PrimaryKeyName #>), cancellationToken);
         }
     }
 }

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Templates/Repository/RepositoryTemplatePartial.cs
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Templates/Repository/RepositoryTemplatePartial.cs
@@ -1,18 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Intent.Engine;
 using Intent.Modelers.Domain.Api;
 using Intent.Modules.Common;
-using Intent.Modules.Common.Plugins;
-using Intent.Modules.Common.Templates;
-using Intent.Modules.Common.VisualStudio;
-using Intent.Modules.Constants;
-using Intent.Modules.EntityFramework.Repositories.Templates.EntityCompositionVisitor;
-using Intent.Modules.EntityFramework.Templates.DbContext;
-using Intent.Engine;
-using Intent.Modules.Common.CSharp;
 using Intent.Modules.Common.CSharp.DependencyInjection;
 using Intent.Modules.Common.CSharp.Templates;
+using Intent.Modules.Common.Templates;
 using Intent.Modules.Entities.Repositories.Api.Templates.EntityRepositoryInterface;
+using Intent.Modules.EntityFramework.Repositories.Templates.EntityCompositionVisitor;
+using Intent.Modules.EntityFramework.Templates.DbContext;
 using Intent.Templates;
 
 namespace Intent.Modules.EntityFramework.Repositories.Templates.Repository
@@ -26,8 +22,8 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.Repository
         private ITemplateDependency _dbContextTemplateDependency;
         private ITemplateDependency _deleteVisitorTemplateDependency;
 
-        public RepositoryTemplate(ClassModel model, IProject project)
-            : base(Identifier, project, model)
+        public RepositoryTemplate(ClassModel model, IOutputTarget outputTarget)
+            : base(Identifier, outputTarget, model)
         {
         }
 
@@ -83,7 +79,7 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.Repository
                 className: $"{Model.Name}Repository",
                 @namespace: $"{OutputTarget.GetNamespace()}");
         }
-        
+
         public override IEnumerable<ITemplateDependency> GetTemplateDependencies()
         {
             // GCB - Looks like an old way of doing things (comment as at V3.0):

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Templates/Repository/RepositoryTemplateRegistration.cs
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Templates/Repository/RepositoryTemplateRegistration.cs
@@ -2,14 +2,11 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using Intent.Engine;
 using Intent.Modelers.Domain.Api;
 using Intent.Modules.Common;
 using Intent.Modules.Common.Registrations;
-using Intent.SoftwareFactory;
-using Intent.Engine;
-using Intent.Modelers.Domain;
 using Intent.Templates;
-
 
 namespace Intent.Modules.EntityFramework.Repositories.Templates.Repository
 {
@@ -39,10 +36,12 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.Repository
             return new RepositoryTemplate(model, project);
         }
 
-        public override IEnumerable<ClassModel> GetModels(Engine.IApplication application)
+        public override IEnumerable<ClassModel> GetModels(IApplication application)
         {
             var allModels = _metadataManager.Domain(application).GetClassModels();
-            var filteredModels = allModels.Where(p => _stereotypeNames.Any(p.HasStereotype));
+            var filteredModels = allModels
+                .Where(p => _stereotypeNames.Any(p.HasStereotype))
+                .ToArray();
 
             if (!filteredModels.Any())
             {

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Templates/RepositoryBase/RepositoryBaseTemplate.cs
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Templates/RepositoryBase/RepositoryBaseTemplate.cs
@@ -75,22 +75,26 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.RepositoryBase
                     "angesAsync();\r\n        }\r\n\r\n        public Task<int> SaveChangesAsync(Cancellati" +
                     "onToken cancellationToken)\r\n        {\r\n            return _dbContext.SaveChanges" +
                     "Async(cancellationToken);\r\n        }\r\n\r\n        public virtual async Task<TDomai" +
-                    "n> FindAsync(Expression<Func<TPersistence, bool>> filterExpression)\r\n        {\r\n" +
-                    "            return await QueryInternal(filterExpression).SingleOrDefaultAsync<TD" +
-                    "omain>();\r\n        }\r\n\r\n        public virtual async Task<List<TDomain>> FindAll" +
-                    "Async()\r\n        {\r\n            return await QueryInternal(x => true).ToListAsyn" +
-                    "c<TDomain>();\r\n        }\r\n        \r\n        public virtual async Task<List<TDoma" +
-                    "in>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression)\r\n      " +
-                    "  {\r\n            return await QueryInternal(filterExpression).ToListAsync<TDomai" +
-                    "n>();\r\n        }\r\n\r\n        public virtual async Task<List<TDomain>> FindAllAsyn" +
-                    "c(Expression<Func<TPersistence, bool>> filterExpression, Func<IQueryable<TPersis" +
-                    "tence>, IQueryable<TPersistence>> linq)\r\n        {\r\n            return await Que" +
-                    "ryInternal(filterExpression, linq).ToListAsync<TDomain>();\r\n        }\r\n\r\n       " +
-                    " public virtual async Task<IPagedResult<TDomain>> FindAllAsync(int pageNo, int p" +
-                    "ageSize)\r\n        {\r\n            var query = QueryInternal(x => true);\r\n        " +
-                    "    return await ");
+                    "n> FindAsync(Expression<Func<TPersistence, bool>> filterExpression, Cancellation" +
+                    "Token cancellationToken = default)\r\n        {\r\n            return await QueryInt" +
+                    "ernal(filterExpression).SingleOrDefaultAsync<TDomain>(cancellationToken);\r\n     " +
+                    "   }\r\n\r\n        public virtual async Task<List<TDomain>> FindAllAsync(Cancellati" +
+                    "onToken cancellationToken = default)\r\n        {\r\n            return await QueryI" +
+                    "nternal(x => true).ToListAsync<TDomain>(cancellationToken);\r\n        }\r\n        " +
+                    "\r\n        public virtual async Task<List<TDomain>> FindAllAsync(Expression<Func<" +
+                    "TPersistence, bool>> filterExpression, CancellationToken cancellationToken = def" +
+                    "ault)\r\n        {\r\n            return await QueryInternal(filterExpression).ToLis" +
+                    "tAsync<TDomain>(cancellationToken);\r\n        }\r\n\r\n        \r\n        public virtu" +
+                    "al async Task<List<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> f" +
+                    "ilterExpression, Func<IQueryable<TPersistence>, IQueryable<TPersistence>> linq, " +
+                    "CancellationToken cancellationToken = default)\r\n        {\r\n            return aw" +
+                    "ait QueryInternal(filterExpression, linq).ToListAsync<TDomain>(cancellationToken" +
+                    ");\r\n        }\r\n\r\n        public virtual async Task<IPagedResult<TDomain>> FindAl" +
+                    "lAsync(int pageNo, int pageSize, CancellationToken cancellationToken = default)\r" +
+                    "\n        {\r\n            var query = QueryInternal(x => true);\r\n            retur" +
+                    "n await ");
             
-            #line 81 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\RepositoryBase\RepositoryBaseTemplate.tt"
+            #line 82 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\RepositoryBase\RepositoryBaseTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(PagedListClassName));
             
             #line default
@@ -101,12 +105,12 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.RepositoryBase
                 pageSize);
         }
         
-        public virtual async Task<IPagedResult<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression, int pageNo, int pageSize)
+        public virtual async Task<IPagedResult<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression, int pageNo, int pageSize, CancellationToken cancellationToken = default)
         {
             var query = QueryInternal(filterExpression);
             return await ");
             
-            #line 90 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\RepositoryBase\RepositoryBaseTemplate.tt"
+            #line 91 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\RepositoryBase\RepositoryBaseTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(PagedListClassName));
             
             #line default
@@ -114,40 +118,44 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.RepositoryBase
             this.Write(@"<TDomain>.CreateAsync(
                 query,
                 pageNo,
-                pageSize);
+                pageSize,
+                cancellationToken);
         }
 
-        public virtual async Task<IPagedResult<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression, int pageNo, int pageSize, Func<IQueryable<TPersistence>, IQueryable<TPersistence>> linq)
+                public virtual async Task<IPagedResult<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression, int pageNo, int pageSize, Func<IQueryable<TPersistence>, IQueryable<TPersistence>> linq, CancellationToken cancellationToken = default)
         {
             var query = QueryInternal(filterExpression, linq);
             return await ");
             
-            #line 99 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\RepositoryBase\RepositoryBaseTemplate.tt"
+            #line 101 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFramework.Repositories\Templates\RepositoryBase\RepositoryBaseTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(PagedListClassName));
             
             #line default
             #line hidden
             this.Write("<TDomain>.CreateAsync(\r\n                query,\r\n                pageNo,\r\n        " +
-                    "        pageSize);\r\n        }\r\n\r\n        public virtual async Task<int> CountAsy" +
-                    "nc(Expression<Func<TPersistence, bool>> filterExpression)\r\n        {\r\n          " +
-                    "  return await QueryInternal(filterExpression).CountAsync();\r\n        }\r\n\r\n     " +
-                    "   public bool Any(Expression<Func<TPersistence, bool>> filterExpression)\r\n     " +
-                    "   {\r\n            return QueryInternal(filterExpression).Any();\r\n        }\r\n\r\n  " +
-                    "      public virtual async Task<bool> AnyAsync(Expression<Func<TPersistence, boo" +
-                    "l>> filterExpression)\r\n        {\r\n            return await QueryInternal(filterE" +
-                    "xpression).AnyAsync();\r\n        }\r\n\r\n        protected virtual IQueryable<TPersi" +
-                    "stence> QueryInternal(Expression<Func<TPersistence, bool>> filterExpression)\r\n  " +
-                    "      {\r\n            var queryable = CreateQuery();\r\n            if (filterExpre" +
-                    "ssion != null)\r\n            {\r\n                queryable = queryable.Where(filte" +
-                    "rExpression);\r\n            }\r\n            return queryable;\r\n        }\r\n\r\n      " +
-                    "  protected virtual IQueryable<TResult> QueryInternal<TResult>(Expression<Func<T" +
-                    "Persistence, bool>> filterExpression, Func<IQueryable<TPersistence>, IQueryable<" +
-                    "TResult>> linq)\r\n        {\r\n            var queryable = CreateQuery();\r\n        " +
-                    "    queryable = queryable.Where(filterExpression);\r\n\r\n            var result = l" +
-                    "inq(queryable);\r\n            return result;\r\n        }\r\n\r\n        protected virt" +
-                    "ual IQueryable<TPersistence> CreateQuery()\r\n        {\r\n            return GetSet" +
-                    "();\r\n        }\r\n\r\n        protected virtual DbSet<TPersistence> GetSet()\r\n      " +
-                    "  {\r\n            return _dbContext.Set<TPersistence>();\r\n        }\r\n    }\r\n}\r\n");
+                    "        pageSize,\r\n                cancellationToken);\r\n        }\r\n\r\n        pub" +
+                    "lic virtual async Task<int> CountAsync(Expression<Func<TPersistence, bool>> filt" +
+                    "erExpression, CancellationToken cancellationToken = default)\r\n        {\r\n       " +
+                    "     return await QueryInternal(filterExpression).CountAsync(cancellationToken);" +
+                    "\r\n        }\r\n\r\n        public bool Any(Expression<Func<TPersistence, bool>> filt" +
+                    "erExpression)\r\n        {\r\n            return QueryInternal(filterExpression).Any" +
+                    "();\r\n        }\r\n\r\n        public virtual async Task<bool> AnyAsync(Expression<Fu" +
+                    "nc<TPersistence, bool>> filterExpression, CancellationToken cancellationToken = " +
+                    "default)\r\n        {\r\n            return await QueryInternal(filterExpression).An" +
+                    "yAsync(cancellationToken);\r\n        }\r\n\r\n        protected virtual IQueryable<TP" +
+                    "ersistence> QueryInternal(Expression<Func<TPersistence, bool>> filterExpression)" +
+                    "\r\n        {\r\n            var queryable = CreateQuery();\r\n            if (filterE" +
+                    "xpression != null)\r\n            {\r\n                queryable = queryable.Where(f" +
+                    "ilterExpression);\r\n            }\r\n            return queryable;\r\n        }\r\n\r\n  " +
+                    "      protected virtual IQueryable<TResult> QueryInternal<TResult>(Expression<Fu" +
+                    "nc<TPersistence, bool>> filterExpression, Func<IQueryable<TPersistence>, IQuerya" +
+                    "ble<TResult>> linq)\r\n        {\r\n            var queryable = CreateQuery();\r\n    " +
+                    "        queryable = queryable.Where(filterExpression);\r\n\r\n            var result" +
+                    " = linq(queryable);\r\n            return result;\r\n        }\r\n\r\n        protected " +
+                    "virtual IQueryable<TPersistence> CreateQuery()\r\n        {\r\n            return Ge" +
+                    "tSet();\r\n        }\r\n\r\n        protected virtual DbSet<TPersistence> GetSet()\r\n  " +
+                    "      {\r\n            return _dbContext.Set<TPersistence>();\r\n        }\r\n    }\r\n}" +
+                    "\r\n");
             return this.GenerationEnvironment.ToString();
         }
     }

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Templates/RepositoryBase/RepositoryBaseTemplate.tt
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Templates/RepositoryBase/RepositoryBaseTemplate.tt
@@ -55,27 +55,28 @@ namespace <#= Namespace #>
             return _dbContext.SaveChangesAsync(cancellationToken);
         }
 
-        public virtual async Task<TDomain> FindAsync(Expression<Func<TPersistence, bool>> filterExpression)
+        public virtual async Task<TDomain> FindAsync(Expression<Func<TPersistence, bool>> filterExpression, CancellationToken cancellationToken = default)
         {
-            return await QueryInternal(filterExpression).SingleOrDefaultAsync<TDomain>();
+            return await QueryInternal(filterExpression).SingleOrDefaultAsync<TDomain>(cancellationToken);
         }
 
-        public virtual async Task<List<TDomain>> FindAllAsync()
+        public virtual async Task<List<TDomain>> FindAllAsync(CancellationToken cancellationToken = default)
         {
-            return await QueryInternal(x => true).ToListAsync<TDomain>();
+            return await QueryInternal(x => true).ToListAsync<TDomain>(cancellationToken);
         }
         
-        public virtual async Task<List<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression)
+        public virtual async Task<List<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression, CancellationToken cancellationToken = default)
         {
-            return await QueryInternal(filterExpression).ToListAsync<TDomain>();
+            return await QueryInternal(filterExpression).ToListAsync<TDomain>(cancellationToken);
         }
 
-        public virtual async Task<List<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression, Func<IQueryable<TPersistence>, IQueryable<TPersistence>> linq)
+        
+        public virtual async Task<List<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression, Func<IQueryable<TPersistence>, IQueryable<TPersistence>> linq, CancellationToken cancellationToken = default)
         {
-            return await QueryInternal(filterExpression, linq).ToListAsync<TDomain>();
+            return await QueryInternal(filterExpression, linq).ToListAsync<TDomain>(cancellationToken);
         }
 
-        public virtual async Task<IPagedResult<TDomain>> FindAllAsync(int pageNo, int pageSize)
+        public virtual async Task<IPagedResult<TDomain>> FindAllAsync(int pageNo, int pageSize, CancellationToken cancellationToken = default)
         {
             var query = QueryInternal(x => true);
             return await <#= PagedListClassName #><TDomain>.CreateAsync(
@@ -84,27 +85,29 @@ namespace <#= Namespace #>
                 pageSize);
         }
         
-        public virtual async Task<IPagedResult<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression, int pageNo, int pageSize)
+        public virtual async Task<IPagedResult<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression, int pageNo, int pageSize, CancellationToken cancellationToken = default)
         {
             var query = QueryInternal(filterExpression);
             return await <#= PagedListClassName #><TDomain>.CreateAsync(
                 query,
                 pageNo,
-                pageSize);
+                pageSize,
+                cancellationToken);
         }
 
-        public virtual async Task<IPagedResult<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression, int pageNo, int pageSize, Func<IQueryable<TPersistence>, IQueryable<TPersistence>> linq)
+                public virtual async Task<IPagedResult<TDomain>> FindAllAsync(Expression<Func<TPersistence, bool>> filterExpression, int pageNo, int pageSize, Func<IQueryable<TPersistence>, IQueryable<TPersistence>> linq, CancellationToken cancellationToken = default)
         {
             var query = QueryInternal(filterExpression, linq);
             return await <#= PagedListClassName #><TDomain>.CreateAsync(
                 query,
                 pageNo,
-                pageSize);
+                pageSize,
+                cancellationToken);
         }
 
-        public virtual async Task<int> CountAsync(Expression<Func<TPersistence, bool>> filterExpression)
+        public virtual async Task<int> CountAsync(Expression<Func<TPersistence, bool>> filterExpression, CancellationToken cancellationToken = default)
         {
-            return await QueryInternal(filterExpression).CountAsync();
+            return await QueryInternal(filterExpression).CountAsync(cancellationToken);
         }
 
         public bool Any(Expression<Func<TPersistence, bool>> filterExpression)
@@ -112,9 +115,9 @@ namespace <#= Namespace #>
             return QueryInternal(filterExpression).Any();
         }
 
-        public virtual async Task<bool> AnyAsync(Expression<Func<TPersistence, bool>> filterExpression)
+        public virtual async Task<bool> AnyAsync(Expression<Func<TPersistence, bool>> filterExpression, CancellationToken cancellationToken = default)
         {
-            return await QueryInternal(filterExpression).AnyAsync();
+            return await QueryInternal(filterExpression).AnyAsync(cancellationToken);
         }
 
         protected virtual IQueryable<TPersistence> QueryInternal(Expression<Func<TPersistence, bool>> filterExpression)

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Templates/RepositoryBase/RepositoryBaseTemplatePartial.cs
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Templates/RepositoryBase/RepositoryBaseTemplatePartial.cs
@@ -1,8 +1,6 @@
 ﻿using Intent.Engine;
 using Intent.Modules.Common;
-using Intent.Modules.Common.CSharp;
 using Intent.Modules.Common.CSharp.Templates;
-using Intent.Modules.Common.Templates;
 using Intent.Modules.Common.VisualStudio;
 using Intent.Modules.Entities.Repositories.Api.Templates.RepositoryInterface;
 using Intent.Modules.EntityFramework.Repositories.Templates.PagedList;
@@ -14,8 +12,8 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.RepositoryBase
     {
         public const string Identifier = "Intent.EntityFramework.Repositories.BaseRepository";
 
-        public RepositoryBaseTemplate(IProject project)
-            : base(Identifier, project)
+        public RepositoryBaseTemplate(IOutputTarget outputTarget)
+            : base(Identifier, outputTarget)
         {
             AddNugetDependency(new NugetPackageInfo("EntityFramework", "6.2.0"));
         }
@@ -26,7 +24,7 @@ namespace Intent.Modules.EntityFramework.Repositories.Templates.RepositoryBase
         protected override CSharpFileConfig DefineFileConfig()
         {
             return new CSharpFileConfig(
-                className: $"RepositoryBase",
+                className: "RepositoryBase",
                 @namespace: $"{OutputTarget.GetNamespace()}");
         }
     }

--- a/Modules/Intent.Modules.EntityFramework.Repositories/Templates/RepositoryBase/RepositoryBaseTemplateRegistration.cs
+++ b/Modules/Intent.Modules.EntityFramework.Repositories/Templates/RepositoryBase/RepositoryBaseTemplateRegistration.cs
@@ -1,29 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
+﻿using System.ComponentModel;
 using Intent.Engine;
-using Intent.Modelers.Domain.Api;
-using Intent.Modules.Common;
 using Intent.Modules.Common.Registrations;
-using Intent.Modules.EntityFramework.Repositories.Templates.RepositoryBase;
 using Intent.Templates;
 
-namespace Intent.Modules.EntityFrameworkCore.Repositories.Templates.RepositoryBase
+namespace Intent.Modules.EntityFramework.Repositories.Templates.RepositoryBase
 {
     [Description(RepositoryBaseTemplate.Identifier)]
-    public class RepositoryBaseTemplateRegistration : NoModelTemplateRegistrationBase
+    public class RepositoryBaseTemplateRegistration : SingleFileTemplateRegistration
     {
-        private readonly IMetadataManager _metadataManager;
-
-        public RepositoryBaseTemplateRegistration(IMetadataManager metadataManager)
-        {
-            _metadataManager = metadataManager;
-        }
-
         public override string TemplateId => RepositoryBaseTemplate.Identifier;
 
-        public override ITemplate CreateTemplateInstance(IProject project)
+        public override ITemplate CreateTemplateInstance(IOutputTarget project)
         {
             return new RepositoryBaseTemplate(project);
         }

--- a/Modules/Intent.Modules.EntityFrameworkCore.Repositories/Templates/Repository/RepositoryTemplate.cs
+++ b/Modules/Intent.Modules.EntityFrameworkCore.Repositories/Templates/Repository/RepositoryTemplate.cs
@@ -42,7 +42,7 @@ namespace Intent.Modules.EntityFrameworkCore.Repositories.Templates.Repository
             
             #line default
             #line hidden
-            this.Write("\r\n{\r\n    [IntentManaged(Mode.Merge)]\r\n\tpublic class ");
+            this.Write("\r\n{\r\n    [IntentManaged(Mode.Merge)]\r\n    public class ");
             
             #line 26 "C:\Dev\Intent.Modules.NET\Modules\Intent.Modules.EntityFrameworkCore.Repositories\Templates\Repository\RepositoryTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(ClassName));

--- a/Modules/Intent.Modules.EntityFrameworkCore.Repositories/Templates/Repository/RepositoryTemplate.tt
+++ b/Modules/Intent.Modules.EntityFrameworkCore.Repositories/Templates/Repository/RepositoryTemplate.tt
@@ -23,7 +23,7 @@ using Microsoft.EntityFrameworkCore;
 namespace <#= Namespace #>
 {
     [IntentManaged(Mode.Merge)]
-	public class <#= ClassName #> : RepositoryBase<<#= EntityInterfaceName #>, <#= EntityName #>, <#= DbContextName #>>, <#= RepositoryContractName #>
+    public class <#= ClassName #> : RepositoryBase<<#= EntityInterfaceName #>, <#= EntityName #>, <#= DbContextName #>>, <#= RepositoryContractName #>
     {
         public <#= ClassName #>(<#= DbContextName #> dbContext) : base (dbContext)
         {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,7 @@
+# We let the build continue on failure to try publish NuGet packages if possible because if one of
+# the projects depends on a NuGet package in the same solution, which hasn't yet been built and
+# published, then it can't do the restore, which means it can't build package to publish it to
+# fix the build.
 trigger:
   batch: true
   branches:
@@ -7,7 +11,8 @@ trigger:
 variables:
   vstsFeed: '4bb4c1b9-5b56-4972-8bac-0ad3fa64204e/intentarchitect-feed'
   targetsToBuild: '**/*.sln'
-  targetsToPack: '' # See 'Intent.Modules' for multi line example
+  targetsToPack: |
+    ;**/Intent.Modules.VisualStudio.Projects.csproj
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -30,6 +35,7 @@ steps:
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet build'
+  condition: succeededOrFailed()
   env:
     DOTNET_NOLOGO: 1
   inputs:
@@ -48,7 +54,7 @@ steps:
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet pack'
-  condition: and(succeeded(), ne(variables['targetsToPack'], ''))
+  condition: and(succeededOrFailed(), ne(variables['targetsToPack'], ''))
   env:
     DOTNET_NOLOGO: '1'
   inputs:
@@ -58,7 +64,7 @@ steps:
 
 - task: NuGetCommand@2
   displayName: 'nuget push'
-  condition: and(succeeded(), ne(variables['targetsToPack'], ''))
+  condition: and(succeededOrFailed(), ne(variables['targetsToPack'], ''))
   inputs:
       command: 'push'
       feedsToUse: 'select'


### PR DESCRIPTION
This PR fixes the DDD entity decorators to respect when `IsCollection` is `true` on associations as right now they are never generated as collections.

I have commented on the two relevant changes in the code as all the other changes can be ignored as they are just formatting and other clean-ups.