### PR TITLE
added setting and code for enabling split queries by default

### DIFF
--- a/Modules/Intent.Modules.EntityFrameworkCore/Intent.EntityFrameworkCore.imodspec
+++ b/Modules/Intent.Modules.EntityFrameworkCore/Intent.EntityFrameworkCore.imodspec
@@ -112,6 +112,10 @@
           <hint>Generates an IApplicationDbContext file when enabled.</hint>
           <defaultValue>false</defaultValue>
         </setting>
+        <setting id="ef908c62-0692-405f-849e-ac09c30181dd" title="Use split queries by default" type="switch">
+          <isRequired>false</isRequired>
+          <hint>Sets UseQuerySplittingBehavior to QuerySplittingBehavior.SplitQuery</hint>
+        </setting>
       </settings>
     </groupExtension>
   </moduleSettingsExtensions>

--- a/Modules/Intent.Modules.EntityFrameworkCore/Intent.Metadata/Module Builder/Intent.EntityFrameworkCore/Elements/Module Settings Extension/bc792686-00cd-43b2-97bf-d91127604c95.xml
+++ b/Modules/Intent.Modules.EntityFrameworkCore/Intent.Metadata/Module Builder/Intent.EntityFrameworkCore/Elements/Module Settings Extension/bc792686-00cd-43b2-97bf-d91127604c95.xml
@@ -239,5 +239,30 @@
       <metadata />
       <childElements />
     </childElement>
+    <childElement id="ef908c62-0692-405f-849e-ac09c30181dd" type="Module Settings Field Configuration" typeId="88e29cab-1342-40c7-b052-5fcd68ffafec">
+      <name>Use split queries by default</name>
+      <display>Use split queries by default</display>
+      <isAbstract>false</isAbstract>
+      <genericTypes />
+      <isMapped>false</isMapped>
+      <parentFolderId>bc792686-00cd-43b2-97bf-d91127604c95</parentFolderId>
+      <packageId>a9d2a398-04e4-4300-9fbb-768568c65f9e</packageId>
+      <packageName>Intent.EntityFrameworkCore</packageName>
+      <stereotypes>
+        <stereotype stereotypeDefinitionId="4805c791-5be3-4049-b929-6046d7be9944" name="Field Configuration">
+          <addedByDefault>true</addedByDefault>
+          <definitionPackageName>Intent.ModuleBuilder</definitionPackageName>
+          <definitionPackageId>9972b2a9-b749-4bba-b5c8-824bf694c6ef</definitionPackageId>
+          <properties>
+            <property name="e33ce4e3-a3c5-4a3c-a6b8-96418be03de0" display="Control Type" value="Switch" isActive="true" />
+            <property name="7070a9ce-ff31-422e-9cff-d82876c5efdf" display="Is Required" value="false" isActive="true" />
+            <property name="01489021-8311-43d5-b41b-e7628a512c1d" display="Hint" value="Sets UseQuerySplittingBehavior to QuerySplittingBehavior.SplitQuery" isActive="true" />
+            <property name="653d889c-626f-45c5-a6e6-72b74a2f805c" display="Default Value" isActive="true" />
+          </properties>
+        </stereotype>
+      </stereotypes>
+      <metadata />
+      <childElements />
+    </childElement>
   </childElements>
 </class>

--- a/Modules/Intent.Modules.EntityFrameworkCore/Settings/ModuleSettingsExtensions.cs
+++ b/Modules/Intent.Modules.EntityFrameworkCore/Settings/ModuleSettingsExtensions.cs
@@ -122,6 +122,8 @@ namespace Intent.Modules.EntityFrameworkCore.Settings
         public static bool LazyLoadingWithProxies(this DatabaseSettings groupSettings) => bool.TryParse(groupSettings.GetSetting("182cdc53-baee-4bb3-adbd-d2a0aa1216a1")?.Value.ToPascalCase(), out var result) && result;
 
         public static bool GenerateDbContextInterface(this DatabaseSettings groupSettings) => bool.TryParse(groupSettings.GetSetting("85dea0e8-8981-4c7b-908e-d99294fc37f1")?.Value.ToPascalCase(), out var result) && result;
+
+        public static bool UseSplitQueriesByDefault(this DatabaseSettings groupSettings) => bool.TryParse(groupSettings.GetSetting("ef908c62-0692-405f-849e-ac09c30181dd")?.Value.ToPascalCase(), out var result) && result;
     }
 
     //public static class ModuleSettingsExtensions


### PR DESCRIPTION
By default, EF Core will load related data using a JOIN, and then normalise this data into a c# object graph.

This can result in a lot of data fetching performance issues, depending on the number of JOIN/`.Includes` used in your queries.

https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries

This PR will enable split queries by default.