### PR TITLE
Fixed: Missing AutoMapper version update added for commercial version

### DIFF
--- a/Modules/Intent.Modules.Application.AutoMapper/Intent.Application.AutoMapper.imodspec
+++ b/Modules/Intent.Modules.Application.AutoMapper/Intent.Application.AutoMapper.imodspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package>
   <id>Intent.Application.AutoMapper</id>
-  <version>5.3.6</version>
+  <version>5.3.7-pre.0</version>
   <supportedClientVersions>[4.1.0-pre.0, 5.0.0-a)</supportedClientVersions>
   <summary>Support for creating Mapping specifications using AutoMapper</summary>
   <description>Support for creating Mapping specifications using AutoMapper</description>

--- a/Modules/Intent.Modules.Application.AutoMapper/NugetPackages.cs
+++ b/Modules/Intent.Modules.Application.AutoMapper/NugetPackages.cs
@@ -49,7 +49,7 @@ namespace Intent.Modules.Application.AutoMapper
             NugetRegistry.Register(AutoMapperPackageName,
                 (framework) => (framework.Major, framework.Minor) switch
                     {
-                        ( >= 10, >= 0) => new PackageVersion("16.0.0")
+                        ( >= 10, >= 0) => new PackageVersion("16.1.1")
                             .WithNugetDependency("Microsoft.Extensions.Logging.Abstractions", "10.0.0")
                             .WithNugetDependency("Microsoft.Extensions.Options", "10.0.0")
                             .WithNugetDependency("Microsoft.IdentityModel.JsonWebTokens", "8.14.0"),

--- a/Modules/Intent.Modules.Application.AutoMapper/release-notes.md
+++ b/Modules/Intent.Modules.Application.AutoMapper/release-notes.md
@@ -1,3 +1,7 @@
+### Version 5.3.7
+
+- Fixed: Missing AutoMapper version update added for commercial version.
+
 ### Version 5.3.6
 
 - Fixed: Updated AutoMapper commercial version to 16.1.1 due to this [security vulnerability](https://github.com/advisories/GHSA-rvv3-g6hj-g44x).


### PR DESCRIPTION
@dandrejvv Unless there's a specific reason, it seemed like there was a missing update here.